### PR TITLE
fix(service): handle empty answers and documents for open questions in ProceedService

### DIFF
--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/proceedtothenextroom/service/ProceedService.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/proceedtothenextroom/service/ProceedService.java
@@ -103,7 +103,14 @@ public class ProceedService {
         roomResponseDto.setDocs(question.getDocuments().stream()
             .map(Document::getPath)
             .toList());
-      } else {
+      } else if (question.getAnswers().isEmpty() && question.getDocuments().isEmpty()) {
+        // Open question: no answers and no documents
+        TableQuestionDto tableQuestionDto = new TableQuestionDto();
+        tableQuestionDto.setQuestionId(question.getId());
+        tableQuestionDto.setQuestion(question.getTitle());
+        tableQuestionDto.setAnswers(new ArrayList<>());
+        tableQuestionDtos.add(tableQuestionDto);
+      }else {
         TableQuestionDto tableQuestionDto = new TableQuestionDto();
         tableQuestionDto.setQuestionId(question.getId());
         tableQuestionDto.setQuestion(question.getTitle());


### PR DESCRIPTION
- Add logic to process open questions with no answers or documents in `ProceedService`.