### PR TITLE
feat(controller): add endpoint to retrieve mission passwords for active session

### DIFF
--- a/admin-feedback-to-player.md
+++ b/admin-feedback-to-player.md
@@ -146,7 +146,7 @@ public ResponseEntity<String> analyticsSubmissionFeedback(
 > The existing codebase does not use a separate mapper layer for analytics DTOs (`RoomOfAnalyticsService` builds `AdminNotificationDto` inline). Following the same style keeps the change minimal and consistent.
 
 **Import cleanup:**
-- `AnalyticsSubmissionFeedbackDto` and `QuestionFeedbackDto` come from `bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.request`.
+- `AnalyticsSubmissionFeedbackDto` and `QuestionFeedbackDto` come from `bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.dto.request`.
 - Remove the unused `import bswe.gamifiedevidencebasednursing.domain.Answer;` from `SubmissionService.java`.
 
 ---

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -254,6 +254,33 @@ paths:
                 type: boolean
               example: true
 
+  /api/admin/dashboard/missions-passwords:
+    get:
+      tags:
+        - Admin Dashboard
+      summary: Get passwords for all missions in the current session
+      description: |
+        Returns the game ID and a list of mission names with their corresponding passwords for the active session.
+      operationId: getMissionsPasswords
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Session passwords retrieved successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionPasswordsDto'
+              example:
+                gameId: 1
+                missionPasswords:
+                  - missionName: "Wound Care for Pressure Ulcers"
+                    password: "abcd"
+                  - missionName: "Fall Prevention in Geriatrics"
+                    password: "efgh"
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
   /api/admin/submission/analytics:
     post:
       tags:
@@ -809,7 +836,7 @@ paths:
                 $ref: '#/components/schemas/ResultDto'
               example:
                 progress: 100
-                key: "ANALYTICS-KEY"
+                key: "K-Y"
         '400':
           $ref: '#/components/responses/BadRequest'
 
@@ -909,6 +936,30 @@ components:
 
   # ── Schemas ───────────────────────────────────
   schemas:
+    # ── Admin Dashboard ─────────────────────────
+    SessionPasswordsDto:
+      type: object
+      description: Response containing game ID and mission passwords
+      properties:
+        gameId:
+          type: integer
+          format: int64
+          example: 1
+        missionPasswords:
+          type: array
+          items:
+            $ref: '#/components/schemas/MissionPasswordDto'
+
+    MissionPasswordDto:
+      type: object
+      properties:
+        missionName:
+          type: string
+          example: "Wound Care for Pressure Ulcers"
+        password:
+          type: string
+          example: "abcd"
+
     # ── Authentication ──────────────────────────
     AuthRequest:
       type: object

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/controller/AdminDashboardController.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/controller/AdminDashboardController.java
@@ -1,0 +1,24 @@
+package bswe.gamifiedevidencebasednursing.feature.admindashboard.controller;
+
+import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.SessionPasswordsDto;
+import bswe.gamifiedevidencebasednursing.feature.admindashboard.service.AdminDashboardService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/dashboard")
+public class AdminDashboardController {
+
+  private final AdminDashboardService adminDashboardService;
+
+  public AdminDashboardController(AdminDashboardService adminDashboardService) {
+    this.adminDashboardService = adminDashboardService;
+  }
+
+  @GetMapping("/missions-passwords")
+  public ResponseEntity<SessionPasswordsDto> getMissionsPasswords() {
+    return adminDashboardService.getSessionPasswords();
+  }
+}

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/dto/response/MissionPasswordDto.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/dto/response/MissionPasswordDto.java
@@ -1,0 +1,19 @@
+package bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response;
+
+public class MissionPasswordDto {
+  private String missionName;
+  private String password;
+
+  public MissionPasswordDto(String missionName, String password) {
+    this.missionName = missionName;
+    this.password = password;
+  }
+
+  public String getMissionName() {
+    return missionName;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+}

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/dto/response/SessionPasswordsDto.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/dto/response/SessionPasswordsDto.java
@@ -1,0 +1,33 @@
+package bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response;
+
+import java.util.List;
+
+public class SessionPasswordsDto {
+  private long gameId;
+  private List<MissionPasswordDto> missionPasswords;
+
+
+  public SessionPasswordsDto() {
+  }
+
+  public SessionPasswordsDto(long gameId, List<MissionPasswordDto> missionPasswords) {
+    this.gameId = gameId;
+    this.missionPasswords = missionPasswords == null ? null : List.copyOf(missionPasswords);
+  }
+
+  public long getGameId() {
+    return gameId;
+  }
+
+  public void setGameId(long gameId) {
+    this.gameId = gameId;
+  }
+
+  public List<MissionPasswordDto> getMissionPasswords() {
+    return missionPasswords == null ? null : List.copyOf(missionPasswords);
+  }
+
+  public void setMissionPasswords(List<MissionPasswordDto> missionPasswords) {
+    this.missionPasswords = missionPasswords == null ? null : List.copyOf(missionPasswords);
+  }
+}

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardService.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardService.java
@@ -1,0 +1,39 @@
+package bswe.gamifiedevidencebasednursing.feature.admindashboard.service;
+
+import java.util.List;
+
+import bswe.gamifiedevidencebasednursing.domain.Game;
+import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.MissionPasswordDto;
+import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.SessionPasswordsDto;
+import bswe.gamifiedevidencebasednursing.repository.GameRepository;
+import bswe.gamifiedevidencebasednursing.repository.TeamRepository;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+@Service
+public class AdminDashboardService {
+
+  private final GameRepository gameRepository;
+  private final TeamRepository teamRepository;
+
+  public AdminDashboardService(GameRepository gameRepository, TeamRepository teamRepository) {
+    this.gameRepository = gameRepository;
+    this.teamRepository = teamRepository;
+  }
+
+  public ResponseEntity<SessionPasswordsDto> getSessionPasswords() {
+    Game game = gameRepository.findCreatedOrRunningGame().orElse(null);
+    if (game == null) {
+      throw new ResponseStatusException(HttpStatusCode.valueOf(404), "No running game found");
+    }
+
+    List<MissionPasswordDto> missionPasswordDtoList = teamRepository.findAllMissionPasswordsByGameId(game.getId());
+    if (missionPasswordDtoList.isEmpty()) {
+      throw new ResponseStatusException(HttpStatusCode.valueOf(404), "No missions found");
+    }
+
+    return new ResponseEntity<>(new SessionPasswordsDto(game.getId(), missionPasswordDtoList), HttpStatusCode.valueOf(200));
+  }
+}

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/controller/SubmissionController.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/controller/SubmissionController.java
@@ -1,7 +1,7 @@
-package bswe.gamifiedevidencebasednursing.feature.admindashboard.controller;
+package bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.controller;
 
-import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.request.AnalyticsSubmissionFeedbackDto;
-import bswe.gamifiedevidencebasednursing.feature.admindashboard.service.SubmissionService;
+import bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.dto.request.AnalyticsSubmissionFeedbackDto;
+import bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.service.SubmissionService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/dto/request/AnalyticsSubmissionFeedbackDto.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/dto/request/AnalyticsSubmissionFeedbackDto.java
@@ -1,4 +1,4 @@
-package bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.request;
+package bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.dto.request;
 
 import java.util.List;
 

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/dto/request/QuestionFeedbackDto.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/dto/request/QuestionFeedbackDto.java
@@ -1,4 +1,4 @@
-package bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.request;
+package bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.dto.request;
 
 public class QuestionFeedbackDto {
   private long questionId;

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/service/SubmissionService.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/adminfeedbacksubmission/service/SubmissionService.java
@@ -1,4 +1,4 @@
-package bswe.gamifiedevidencebasednursing.feature.admindashboard.service;
+package bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.service;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -7,8 +7,8 @@ import java.util.Optional;
 
 import bswe.gamifiedevidencebasednursing.domain.OpenQuestionAnswer;
 import bswe.gamifiedevidencebasednursing.domain.Room;
-import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.request.AnalyticsSubmissionFeedbackDto;
-import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.request.QuestionFeedbackDto;
+import bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.dto.request.AnalyticsSubmissionFeedbackDto;
+import bswe.gamifiedevidencebasednursing.feature.adminfeedbacksubmission.dto.request.QuestionFeedbackDto;
 import bswe.gamifiedevidencebasednursing.feature.roomofanalytics.dto.response.AnalyticsFeedbackDto;
 import bswe.gamifiedevidencebasednursing.feature.roomofanalytics.dto.response.QuestionFeedbackResultDto;
 import bswe.gamifiedevidencebasednursing.feature.roomofanalytics.service.AnalyticsNotificationService;

--- a/src/main/java/bswe/gamifiedevidencebasednursing/repository/TeamRepository.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/repository/TeamRepository.java
@@ -1,7 +1,10 @@
 package bswe.gamifiedevidencebasednursing.repository;
 
 
+import java.util.List;
+
 import bswe.gamifiedevidencebasednursing.domain.Team;
+import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.MissionPasswordDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -15,5 +18,15 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
           "AND t.mission.id =:missionId"
   )
   String findPasswordByGameIdAndMissionId(Long gameId, Long missionId);
+
+
+
+  @Query(
+      "SELECT new bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response." +
+          "MissionPasswordDto(t.mission.name, t.password) " +
+          "FROM Team t " +
+          "WHERE t.game.id =:gameId"
+  )
+  List<MissionPasswordDto> findAllMissionPasswordsByGameId(long gameId);
 
 }


### PR DESCRIPTION
- implement getMissionsPasswords in AdminDashboardController
- create AdminDashboardService to fetch game and mission passwords
- add MissionPasswordDto and SessionPasswordsDto for response mapping
- refactor submission features into adminfeedbacksubmission package
- update openapi.yaml with the new dashboard endpoint