### PR TITLE
feat(controller): add close game session endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -66,6 +66,8 @@ tags:
     description: Room of Analytics specific endpoints
   - name: Room of Science Battle
     description: Room of Science Battle specific endpoints
+  - name: Retry Rooms
+    description: Endpoints to reset progress in themed rooms
   - name: Room Time
     description: Room Time specific endpoints — calculate remaining time for a room
   - name: WebSockets
@@ -280,6 +282,24 @@ paths:
                     password: "efgh"
         '401':
           $ref: '#/components/responses/Unauthorized'
+
+  /api/admin/dashboard/close-game-session:
+    post:
+      tags:
+        - Admin Dashboard
+      summary: Close the current game session
+      description: |
+        Ends the active game session, calculates winners based on the number of rooms completed by each team, and sets the game status to FINISHED.
+      operationId: closeGameSession
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Game session closed successfully
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
 
   /api/admin/submission/analytics:
     post:
@@ -595,7 +615,7 @@ paths:
   /api/rooms/retry/knowledge:
     put:
       tags:
-        - Room of Knowledge
+        - Retry Rooms
       summary: Retry Room of Knowledge
       description: |
         Resets the progress of a specific room in the Room of Knowledge to 0.
@@ -623,7 +643,7 @@ paths:
   /api/rooms/retry/abstracts:
     put:
       tags:
-        - Room of Abstracts
+        - Retry Rooms
       summary: Retry Room of Abstracts
       description: |
         Resets the progress of a specific room in the Room of Abstracts to 0.
@@ -1020,6 +1040,10 @@ components:
         password:
           type: string
           example: "abcd"
+        isWinner:
+          type: boolean
+          description: Whether the team is a winner of the game session
+          example: false
 
     # ── Landing Page ────────────────────────────
     LandingPageResponse:
@@ -1449,6 +1473,23 @@ components:
           example: "Increased heart rate"
 
     # ── Error ───────────────────────────────────
+    GameStatus:
+      type: string
+      enum:
+        - CREATED
+        - RUNNING
+        - FINISHED
+      description: Status of a game session
+
+    TeamStatus:
+      type: string
+      enum:
+        - READY
+        - STARTED
+        - WAITING_APPROVAL
+        - FINISHED
+      description: Status of a team in the game
+
     ErrorResponse:
       type: object
       properties:

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/controller/AdminDashboardController.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/controller/AdminDashboardController.java
@@ -4,6 +4,7 @@ import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.Ses
 import bswe.gamifiedevidencebasednursing.feature.admindashboard.service.AdminDashboardService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +21,10 @@ public class AdminDashboardController {
   @GetMapping("/missions-passwords")
   public ResponseEntity<SessionPasswordsDto> getMissionsPasswords() {
     return adminDashboardService.getSessionPasswords();
+  }
+
+  @PostMapping("close-game-session")
+  public ResponseEntity<Void> closeGameSession() {
+   return adminDashboardService.closeGameSession();
   }
 }

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/controller/AdminDashboardController.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/controller/AdminDashboardController.java
@@ -23,7 +23,7 @@ public class AdminDashboardController {
     return adminDashboardService.getSessionPasswords();
   }
 
-  @PostMapping("close-game-session")
+  @PostMapping("/close-game-session")
   public ResponseEntity<Void> closeGameSession() {
    return adminDashboardService.closeGameSession();
   }

--- a/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardService.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardService.java
@@ -1,11 +1,16 @@
 package bswe.gamifiedevidencebasednursing.feature.admindashboard.service;
 
+import java.time.Instant;
 import java.util.List;
 
 import bswe.gamifiedevidencebasednursing.domain.Game;
+import bswe.gamifiedevidencebasednursing.domain.Room;
+import bswe.gamifiedevidencebasednursing.domain.Team;
+import bswe.gamifiedevidencebasednursing.domain.enums.GameStatus;
 import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.MissionPasswordDto;
 import bswe.gamifiedevidencebasednursing.feature.admindashboard.dto.response.SessionPasswordsDto;
 import bswe.gamifiedevidencebasednursing.repository.GameRepository;
+import bswe.gamifiedevidencebasednursing.repository.RoomRepository;
 import bswe.gamifiedevidencebasednursing.repository.TeamRepository;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -17,17 +22,17 @@ public class AdminDashboardService {
 
   private final GameRepository gameRepository;
   private final TeamRepository teamRepository;
+  private final RoomRepository roomRepository;
 
-  public AdminDashboardService(GameRepository gameRepository, TeamRepository teamRepository) {
+  public AdminDashboardService(GameRepository gameRepository, TeamRepository teamRepository,
+                               RoomRepository roomRepository) {
     this.gameRepository = gameRepository;
     this.teamRepository = teamRepository;
+    this.roomRepository = roomRepository;
   }
 
   public ResponseEntity<SessionPasswordsDto> getSessionPasswords() {
-    Game game = gameRepository.findCreatedOrRunningGame().orElse(null);
-    if (game == null) {
-      throw new ResponseStatusException(HttpStatusCode.valueOf(404), "No running game found");
-    }
+    Game game = findCreatedOrRunningGame();
 
     List<MissionPasswordDto> missionPasswordDtoList = teamRepository.findAllMissionPasswordsByGameId(game.getId());
     if (missionPasswordDtoList.isEmpty()) {
@@ -35,5 +40,69 @@ public class AdminDashboardService {
     }
 
     return new ResponseEntity<>(new SessionPasswordsDto(game.getId(), missionPasswordDtoList), HttpStatusCode.valueOf(200));
+  }
+
+  public ResponseEntity<Void> closeGameSession() {
+    Instant now = Instant.now();
+    Game game = findCreatedOrRunningGame();
+
+    List<Team> teams = teamRepository.findByGameIdWithRooms(game.getId());
+
+    boolean allRoomsUnstarted = true;
+    for (Team team : teams) {
+      for (Room room : team.getRoomList()) {
+        if (room.getStartTime() != null || room.getEndTime() != null) {
+          allRoomsUnstarted = false;
+          break;
+        }
+      }
+      if (!allRoomsUnstarted) {
+        break;
+      }
+    }
+
+    if (allRoomsUnstarted) {
+      gameRepository.delete(game);
+      return ResponseEntity.ok().build();
+    }
+
+    game.setStatus(GameStatus.FINISHED);
+    game.setFinish(now);
+
+    int maxRooms = 0;
+    for (Team team : teams) {
+      List<Room> rooms = team.getRoomList();
+      int roomCount = rooms.size();
+      if (roomCount > maxRooms) {
+        maxRooms = roomCount;
+      }
+      for (Room room : rooms) {
+        if (room.getStartTime() != null && room.getEndTime() == null) {
+          room.setEndTime(now);
+        } else if (room.getStartTime() == null && room.getEndTime() == null) {
+          room.setStartTime(now);
+          room.setEndTime(now);
+        }
+      }
+      roomRepository.saveAll(rooms);
+    }
+
+    if (maxRooms > 0) {
+      for (Team team : teams) {
+        team.setWinner(team.getRoomList().size() == maxRooms);
+      }
+      teamRepository.saveAll(teams);
+    }
+    gameRepository.save(game);
+
+    return ResponseEntity.ok().build();
+  }
+
+  private Game findCreatedOrRunningGame() {
+    Game game = gameRepository.findCreatedOrRunningGame().orElse(null);
+    if (game == null) {
+      throw new ResponseStatusException(HttpStatusCode.valueOf(404), "No running game found");
+    }
+    return game;
   }
 }

--- a/src/main/java/bswe/gamifiedevidencebasednursing/repository/RoomRepository.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/repository/RoomRepository.java
@@ -1,6 +1,7 @@
 package bswe.gamifiedevidencebasednursing.repository;
 
 
+
 import bswe.gamifiedevidencebasednursing.domain.Room;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/bswe/gamifiedevidencebasednursing/repository/TeamRepository.java
+++ b/src/main/java/bswe/gamifiedevidencebasednursing/repository/TeamRepository.java
@@ -29,4 +29,7 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
   )
   List<MissionPasswordDto> findAllMissionPasswordsByGameId(long gameId);
 
+  @Query("SELECT t FROM Team t LEFT JOIN FETCH t.roomList WHERE t.game.id = :gameId")
+  List<Team> findByGameIdWithRooms(Long gameId);
+
 }

--- a/src/test/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardServiceTest.java
+++ b/src/test/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardServiceTest.java
@@ -4,6 +4,7 @@ import bswe.gamifiedevidencebasednursing.domain.Game;
 import bswe.gamifiedevidencebasednursing.domain.Room;
 import bswe.gamifiedevidencebasednursing.domain.Team;
 import bswe.gamifiedevidencebasednursing.repository.GameRepository;
+import bswe.gamifiedevidencebasednursing.repository.RoomRepository;
 import bswe.gamifiedevidencebasednursing.repository.TeamRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,8 @@ class AdminDashboardServiceTest {
     private GameRepository gameRepository;
     @Mock
     private TeamRepository teamRepository;
+    @Mock
+    private RoomRepository roomRepository;
 
     @InjectMocks
     private AdminDashboardService adminDashboardService;

--- a/src/test/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardServiceTest.java
+++ b/src/test/java/bswe/gamifiedevidencebasednursing/feature/admindashboard/service/AdminDashboardServiceTest.java
@@ -1,0 +1,141 @@
+package bswe.gamifiedevidencebasednursing.feature.admindashboard.service;
+
+import bswe.gamifiedevidencebasednursing.domain.Game;
+import bswe.gamifiedevidencebasednursing.domain.Room;
+import bswe.gamifiedevidencebasednursing.domain.Team;
+import bswe.gamifiedevidencebasednursing.repository.GameRepository;
+import bswe.gamifiedevidencebasednursing.repository.TeamRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class AdminDashboardServiceTest {
+
+    @Mock
+    private GameRepository gameRepository;
+    @Mock
+    private TeamRepository teamRepository;
+
+    @InjectMocks
+    private AdminDashboardService adminDashboardService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void closeGameSession_shouldDetermineWinnerCorrectly() {
+        // Given
+        Game game = new Game();
+        try {
+            java.lang.reflect.Field idField = Game.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(game, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        when(gameRepository.findCreatedOrRunningGame()).thenReturn(Optional.of(game));
+
+        Team team1 = new Team();
+        team1.setId(1L);
+        Team team2 = new Team();
+        team2.setId(2L);
+        List<Team> teams = Arrays.asList(team1, team2);
+        when(teamRepository.findByGameIdWithRooms(1L)).thenReturn(teams);
+
+        Room room1_1 = new Room();
+        room1_1.setStartTime(java.time.Instant.now());
+        Room room1_2 = new Room();
+        team1.setRoomList(Arrays.asList(room1_1, room1_2));
+
+        Room room2_1 = new Room();
+        team2.setRoomList(Collections.singletonList(room2_1));
+
+        // When
+        adminDashboardService.closeGameSession();
+
+        // Then
+        assertTrue(team1.isWinner());
+        assertFalse(team2.isWinner());
+        verify(teamRepository).saveAll(any());
+    }
+
+    @Test
+    void closeGameSession_shouldHandleMultipleWinners() {
+        // Given
+        Game game = new Game();
+        try {
+            java.lang.reflect.Field idField = Game.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(game, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        when(gameRepository.findCreatedOrRunningGame()).thenReturn(Optional.of(game));
+
+        Team team1 = new Team();
+        team1.setId(1L);
+        Team team2 = new Team();
+        team2.setId(2L);
+        List<Team> teams = Arrays.asList(team1, team2);
+        when(teamRepository.findByGameIdWithRooms(1L)).thenReturn(teams);
+
+        Room room1_1 = new Room();
+        room1_1.setStartTime(java.time.Instant.now());
+        team1.setRoomList(Collections.singletonList(room1_1));
+
+        Room room2_1 = new Room();
+        room2_1.setStartTime(java.time.Instant.now());
+        team2.setRoomList(Collections.singletonList(room2_1));
+
+        // When
+        adminDashboardService.closeGameSession();
+
+        // Then
+        assertTrue(team1.isWinner());
+        assertTrue(team2.isWinner());
+        verify(teamRepository).saveAll(any());
+    }
+
+    @Test
+    void closeGameSession_shouldDeleteGameIfAllRoomsNotStarted() {
+        // Given
+        Game game = new Game();
+        try {
+            java.lang.reflect.Field idField = Game.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(game, 1L);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        when(gameRepository.findCreatedOrRunningGame()).thenReturn(Optional.of(game));
+
+        Team team1 = new Team();
+        team1.setId(1L);
+        Room room1 = new Room();
+        room1.setStartTime(null);
+        room1.setEndTime(null);
+        team1.setRoomList(Collections.singletonList(room1));
+
+        List<Team> teams = Collections.singletonList(team1);
+        when(teamRepository.findByGameIdWithRooms(1L)).thenReturn(teams);
+
+        // When
+        adminDashboardService.closeGameSession();
+
+        // Then
+        verify(gameRepository).delete(game);
+        verify(gameRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
- implement closeGameSession in AdminDashboardController and AdminDashboardService
- add logic to calculate winners and finalize room times upon closing a session
- update openapi.yaml with the new endpoint and related schema changes
- add repository methods for fetching teams with rooms and rooms by team id
- include unit tests for the new admin dashboard service functionality